### PR TITLE
Feature: schedulesを時間順に整列

### DIFF
--- a/src/components/Navigation/Navbar/Navbar.jsx
+++ b/src/components/Navigation/Navbar/Navbar.jsx
@@ -101,7 +101,7 @@ const Navbar = (props) => {
             >
               <p style={{ marginTop: "0", marginRight: "4px" }}>🔴</p>
               {/* <LabelIcon className={classes.SuperPremiumIcon} /> */}
-              <div>スーパープレミアム以上限定</div>
+              <div>スーパープレミアム限定</div>
             </Box>
           </li>
         </ul>

--- a/src/components/Schedule/Schedule.jsx
+++ b/src/components/Schedule/Schedule.jsx
@@ -25,12 +25,6 @@ const Schedule = (props) => {
         : null;
     });
 
-    const colorList = {
-      制限なし: "all",
-      プレミアム: "premium",
-      スーパープレミアム: "superPremium",
-    };
-
     return schedules.map((schedule, index) => {
       let circle;
       switch (schedule.plan) {

--- a/src/components/Schedule/Schedule.jsx
+++ b/src/components/Schedule/Schedule.jsx
@@ -12,12 +12,14 @@ const Schedule = (props) => {
 
   const showSchedule = (event, schedule, day, index) => {
     event.stopPropagation();
+
     props.setSelectedSchedule(day, index);
     props.openCurrentModal(schedule);
   };
 
   const renderSchedule = () => {
     if (!props.schedules) return;
+
     const schedules = [];
     Object.keys(props.schedules).map((scheduleKey) => {
       return props.schedules[scheduleKey].date === day
@@ -41,15 +43,32 @@ const Schedule = (props) => {
 
       return (
         <Box key={index}>
-          <Button
-            className={classes.ScheduleBtn}
-            onClick={(event) => showSchedule(event, schedule, day, index)}
-          >
-            {circle}
-            <p
-              style={{ margin: "0", fontSize: "12px" }}
-            >{`${schedule.startTime} ${schedule.title}`}</p>
-          </Button>
+          {schedule.plan === "holiday" ? (
+            <Button
+              style={{
+                width: "100%",
+                backgroundColor: "green",
+                color: "white",
+                padding: "2px",
+                marginTop: "4px",
+                fontSize: "12px",
+              }}
+              onClick={(event) => showSchedule(event, schedule, day, index)}
+            >
+              {schedule.title}
+            </Button>
+          ) : (
+            <Button
+              className={classes.ScheduleBtn}
+              style={{ padding: "4px 8px" }}
+              onClick={(event) => showSchedule(event, schedule, day, index)}
+            >
+              {circle}
+              <p
+                style={{ margin: "0", fontSize: "12px" }}
+              >{`${schedule.startTime} ${schedule.title}`}</p>
+            </Button>
+          )}
         </Box>
       );
     });

--- a/src/components/Schedule/Schedule.module.scss
+++ b/src/components/Schedule/Schedule.module.scss
@@ -1,20 +1,20 @@
-.all {
-  background-color: #059BE5;
-  border-radius: 5px;
-  margin-top: 5px;
-}
+// .all {
+//   background-color: #059BE5;
+//   border-radius: 5px;
+//   margin-top: 5px;
+// }
 
-.premium {
-  background-color: green;
-  border-radius: 5px;
-  margin-top: 5px;
-}
+// .premium {
+//   background-color: green;
+//   border-radius: 5px;
+//   margin-top: 5px;
+// }
 
-.superPremium {
-  background-color: red;
-  border-radius: 5px;
-  margin-top: 5px;
-}
+// .superPremium {
+//   background-color: red;
+//   border-radius: 5px;
+//   margin-top: 5px;
+// }
 
 .ScheduleBtn {
   width: 100%;

--- a/src/components/Schedule/Schedule.module.scss
+++ b/src/components/Schedule/Schedule.module.scss
@@ -19,7 +19,6 @@
 .ScheduleBtn {
   width: 100%;
   font-size: 12px;
-  padding: 2px;
 }
 
 .ScheduleBtn span {

--- a/src/container/CalendarBoard/CalendarBoard.jsx
+++ b/src/container/CalendarBoard/CalendarBoard.jsx
@@ -96,6 +96,7 @@ const CalendarBoard = (props) => {
           return (
             <CalendarElement
               day={day}
+              weekDay={dayIndex}
               weekLength={dateState.length}
               key={dayIndex}
             />

--- a/src/container/CalendarElement/CalendarElement.jsx
+++ b/src/container/CalendarElement/CalendarElement.jsx
@@ -23,8 +23,6 @@ const CalendarElement = (props) => {
   const day =
     props.day.getDate() === 1 && !isToday ? firstDay : props.day.getDate();
 
-  console.log(props.weekDay);
-
   let dayColor;
   if (props.weekDay % 7 === 6 && !isToday) {
     dayColor = "blue";

--- a/src/container/CalendarElement/CalendarElement.jsx
+++ b/src/container/CalendarElement/CalendarElement.jsx
@@ -23,16 +23,25 @@ const CalendarElement = (props) => {
   const day =
     props.day.getDate() === 1 && !isToday ? firstDay : props.day.getDate();
 
+  console.log(props.weekDay);
+
+  let dayColor;
+  if (props.weekDay % 7 === 6 && !isToday) {
+    dayColor = "blue";
+  } else if (props.weekDay % 7 === 0 && !isToday) {
+    dayColor = "red";
+  }
+
   return (
     <div
       className={classes.CalendarEl}
-      style={{ height: `calc(85vh / ${props.weekLength})` }}
+      style={{ height: `calc(86vh / ${props.weekLength})` }}
       onClick={() => onClickHandler(props.day)}
     >
       <Box display="flex" justifyContent="center">
         <p
           className={isToday ? classes.today : classes.notToday}
-          style={{ opacity: opacity }}
+          style={{ opacity: opacity, color: dayColor }}
         >
           {day}
         </p>

--- a/src/container/CalendarElement/CalendarElement.module.scss
+++ b/src/container/CalendarElement/CalendarElement.module.scss
@@ -25,4 +25,5 @@
 
 .notToday {
   padding-top: 4px;
+  height: 16px;
 }

--- a/src/container/CalendarElement/CalendarElement.module.scss
+++ b/src/container/CalendarElement/CalendarElement.module.scss
@@ -8,7 +8,6 @@
   overflow: scroll;
   text-overflow: ellipsis;
   white-space: nowrap;
-  overflow-y: scroll;
 
   p {
     margin-top: 5px;

--- a/src/container/CurrentSchedule/CurrentSchedule.jsx
+++ b/src/container/CurrentSchedule/CurrentSchedule.jsx
@@ -19,37 +19,29 @@ const CurrentSchedule = (props) => {
     <DialogContent>
       <div className={classes.content}>
         <p className={classes.title}>{props.selectedSchedule.title}</p>
-        <Box
-          display="flex"
-          justifyContent="space-between"
-          width="70%"
-          className={classes.dateTime}
-        >
-          <p>{props.selectedSchedule.date}</p>
-          <p>
-            {`${props.selectedSchedule.startTime} ~ ${props.selectedSchedule.endTime}`}
-          </p>
-        </Box>
+        {props.selectedSchedule.plan !== "holiday" && (
+          <Box
+            display="flex"
+            justifyContent="space-between"
+            width="70%"
+            className={classes.dateTime}
+          >
+            <p>{props.selectedSchedule.date}</p>
+            <p>
+              {`${props.selectedSchedule.startTime} ~ ${props.selectedSchedule.endTime}`}
+            </p>
+          </Box>
+        )}
       </div>
       {props.selectedSchedule.owner && (
-        <Box
-          display="flex"
-          justifyContent="space-between"
-          width="70px"
-          className={classes.owner}
-        >
-          <PeopleAltOutlinedIcon />
+        <Box display="flex" alignItems="center" className={classes.owner}>
+          <PeopleAltOutlinedIcon style={{ marginRight: "8px" }} />
           <p>{props.selectedSchedule.owner}</p>
         </Box>
       )}
       {props.selectedSchedule.description && (
-        <Box
-          display="flex"
-          justifyContent="space-between"
-          width="70px"
-          className={classes.information}
-        >
-          <SubjectIcon />
+        <Box display="flex" alignItems="center" className={classes.information}>
+          <SubjectIcon style={{ marginRight: "8px" }} />
           <p>{props.selectedSchedule.description}</p>
         </Box>
       )}

--- a/src/store/actions/schedule.jsx
+++ b/src/store/actions/schedule.jsx
@@ -3,9 +3,22 @@ import axios from "../../axios-schedules";
 import { openErrorModal } from "./showModal";
 
 export const setSchedules = (schedules) => {
+  const orderedSchedules = Object.keys(schedules).map((scheduleKey) => {
+    return Object.assign(schedules[scheduleKey], { id: scheduleKey });
+  });
+
+  // スケジュールを時間順で並び替える
+  orderedSchedules.sort(function (a, b) {
+    if (a.startTime < b.startTime) {
+      return -1;
+    } else {
+      return 1;
+    }
+  });
+
   return {
     type: actionTypes.SET_SCHEDULES,
-    schedules: schedules,
+    schedules: orderedSchedules,
   };
 };
 

--- a/src/store/reducers/schedule.jsx
+++ b/src/store/reducers/schedule.jsx
@@ -19,25 +19,18 @@ const reducer = (state = initialState, action) => {
         error: action.error,
       };
     case actionTypes.SET_SELECTED_SCHEDULE:
-      const schedules = [];
-      const selectedSchedules = { ...state.schedules };
-      let count = 0; //countによって日付が同じ日の中でindexをカウントする
-      Object.keys(selectedSchedules).map((scheduleKey) => {
-        if (selectedSchedules[scheduleKey].date === action.day) {
-          schedules.push({
-            ...selectedSchedules[scheduleKey],
-            id: scheduleKey,
-          });
-          count === action.index
-            ? (selectedSchedules[scheduleKey].selected = true)
-            : (selectedSchedules[scheduleKey].selected = false); //同じ日付の中でもselectedにするものを1つだけにするため
-          count += 1;
-        } else {
-          return (selectedSchedules[scheduleKey].selected = false);
-        }
+      const schedules = [...state.schedules];
+      const selectedDaySchedules = schedules.filter((schedule) => {
+        return schedule.date === action.day;
       });
 
-      const selectedSchedule = schedules[action.index];
+      const selectedSchedules = selectedDaySchedules.map((schedule, index) => {
+        schedule.selected = index === action.index;
+
+        return schedule;
+      });
+
+      const selectedSchedule = selectedSchedules[action.index];
 
       return {
         ...state,


### PR DESCRIPTION
scheduleを後から追加しても時間順に表示されるように変更

fetchした時に時間順にソートした上でschedulesに配列で格納するようにした。
この時にオブジェクトの中にidを格納した。

これに合わせてsetSchedulesのreducer内の処理をシンプルにした。