### PR TITLE
Fix: selectedSchedulesによるstateの変更をしない

### DIFF
--- a/src/store/reducers/schedule.jsx
+++ b/src/store/reducers/schedule.jsx
@@ -24,6 +24,7 @@ const reducer = (state = initialState, action) => {
         return schedule.date === action.day;
       });
 
+      // selectedのプロパティ必要ない？？
       const selectedSchedules = selectedDaySchedules.map((schedule, index) => {
         schedule.selected = index === action.index;
 
@@ -34,7 +35,7 @@ const reducer = (state = initialState, action) => {
 
       return {
         ...state,
-        schedules: selectedSchedules,
+        // schedules: selectedSchedules,
         selectedSchedule: selectedSchedule,
       };
     case actionTypes.REMOVE_SCHEDULE:


### PR DESCRIPTION
scheduleを選択した時にstateのschedulesを変更していたが、これを行わないようにした。

選択後にモーダルを閉じると更新されたそのscheduleだけが表示されるようになってしまったため。